### PR TITLE
Update factory bindings to reference the proper class.

### DIFF
--- a/src/ZondiconsServiceProvider.php
+++ b/src/ZondiconsServiceProvider.php
@@ -10,7 +10,7 @@ class ZondiconsServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        app(IconFactory::class)->registerBladeTag();
+        app(SvgFactory::class)->registerBladeTag();
 
         $this->publishes([
             __DIR__.'/../config/zondicons.php' => config_path('zondicons.php'),
@@ -19,7 +19,7 @@ class ZondiconsServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->app->singleton(IconFactory::class, function () {
+        $this->app->singleton(SvgFactory::class, function () {
             $config = array_merge([
                 'icon_path' => base_path('vendor/zondicons/blade-bridge/resources/icons'),
                 'spritesheet_path' => base_path('vendor/zondicons/blade-bridge/resources/sprite.svg'),


### PR DESCRIPTION
The `nothingworks/blade-svg` package was updated in the [0.1.6](https://github.com/dukestreetstudio/zondicons-blade-bridge/releases/tag/v0.1.6) release. The [main change](https://github.com/dukestreetstudio/zondicons-blade-bridge/commit/cfd4faa1bb82ae77955794ba92c8f7f785efe9b2) in this package was updating the class name from `BladeSvg\IconFactory` to `BladeSvg\SvgFactory`. However, the container bindings were never updated, meaning that _this_ package still registers the `SvgFactory` as `"BladeSvg\IconFactory"`, which will never be loaded.

The result is that `nothingworks/blade-svg` will resolve whatever default `SvgFactory` is defined there, ignoring the configuration options this package sets. Ultimately, this results in a [`ViewException`](https://flareapp.io/share/LPdlqbPO#F58) when using `@icon('icon-name')` since it will attempt to load the SVG from the default location rather than `vendor/zondicons/blade-bridge/resources/*`.

This PR simply updates the container bindings to reference the proper class. I tested this by manually applying the same changes to `vendor/zondicons/blade-bridge/src/ZondiconsServiceProvider.php` in a Laravel project. 